### PR TITLE
Extract useMovementInteraction and MovablePointSVG from MovablePoint

### DIFF
--- a/.api-report/mafs.api.md
+++ b/.api-report/mafs.api.md
@@ -149,6 +149,21 @@ export interface MovablePointProps {
 }
 
 // @public (undocumented)
+export const MovablePointSVG: React_2.ForwardRefExoticComponent<MovablePointSVGProps & React_2.RefAttributes<SVGGElement>>;
+
+// @public (undocumented)
+export interface MovablePointSVGProps {
+    // (undocumented)
+    color: string;
+    // (undocumented)
+    dragging: boolean;
+    // (undocumented)
+    point: vec.Vector2;
+    // (undocumented)
+    ringRadiusPx: number;
+}
+
+// @public (undocumented)
 export interface OfXProps extends Omit<ParametricProps, "xy" | "t"> {
     // (undocumented)
     svgPathProps?: React_2.SVGProps<SVGPathElement>;
@@ -372,6 +387,16 @@ export interface UseMovablePointArguments {
     color?: string;
     constrain?: "horizontal" | "vertical" | ConstraintFunction;
 }
+
+// @public (undocumented)
+export function useMovementInteraction({ target, onMove, point, constrain, }: {
+    target: React_2.RefObject<Element>;
+    onMove: (point: vec.Vector2) => unknown;
+    point: vec.Vector2;
+    constrain: (point: vec.Vector2) => vec.Vector2;
+}): {
+    dragging: boolean;
+};
 
 // Warning: (ae-forgotten-export) The symbol "PaneContextShape" needs to be exported by the entry point index.d.ts
 //

--- a/.api-report/mafs.api.md
+++ b/.api-report/mafs.api.md
@@ -139,6 +139,21 @@ export namespace MovablePoint {
 }
 
 // @public (undocumented)
+export const MovablePointDisplay: React_2.ForwardRefExoticComponent<MovablePointDisplayProps & React_2.RefAttributes<SVGGElement>>;
+
+// @public (undocumented)
+export interface MovablePointDisplayProps {
+    // (undocumented)
+    color?: string;
+    // (undocumented)
+    dragging: boolean;
+    // (undocumented)
+    point: vec.Vector2;
+    // (undocumented)
+    ringRadiusPx?: number;
+}
+
+// @public (undocumented)
 export interface MovablePointProps {
     // (undocumented)
     color?: string;
@@ -146,21 +161,6 @@ export interface MovablePointProps {
     constrain?: ConstraintFunction_2;
     onMove: (point: vec.Vector2) => void;
     point: vec.Vector2;
-}
-
-// @public (undocumented)
-export const MovablePointSVG: React_2.ForwardRefExoticComponent<MovablePointSVGProps & React_2.RefAttributes<SVGGElement>>;
-
-// @public (undocumented)
-export interface MovablePointSVGProps {
-    // (undocumented)
-    color: string;
-    // (undocumented)
-    dragging: boolean;
-    // (undocumented)
-    point: vec.Vector2;
-    // (undocumented)
-    ringRadiusPx: number;
 }
 
 // @public (undocumented)
@@ -389,14 +389,25 @@ export interface UseMovablePointArguments {
 }
 
 // @public (undocumented)
-export function useMovementInteraction({ target, onMove, point, constrain, }: {
-    target: React_2.RefObject<Element>;
-    onMove: (point: vec.Vector2) => unknown;
-    point: vec.Vector2;
-    constrain: (point: vec.Vector2) => vec.Vector2;
-}): {
+export interface UseMovementInteraction {
+    // (undocumented)
     dragging: boolean;
-};
+}
+
+// @public (undocumented)
+export function useMovementInteraction(args: UseMovementInteractionArguments): UseMovementInteraction;
+
+// @public (undocumented)
+export interface UseMovementInteractionArguments {
+    // (undocumented)
+    constrain: (point: vec.Vector2) => vec.Vector2;
+    // (undocumented)
+    gestureTarget: React_2.RefObject<Element>;
+    // (undocumented)
+    onMove: (point: vec.Vector2) => unknown;
+    // (undocumented)
+    point: vec.Vector2;
+}
 
 // Warning: (ae-forgotten-export) The symbol "PaneContextShape" needs to be exported by the entry point index.d.ts
 //

--- a/src/display/MovablePointDisplay.test.ts
+++ b/src/display/MovablePointDisplay.test.ts
@@ -1,0 +1,7 @@
+import { MovablePointDisplay } from "./MovablePointDisplay"
+
+describe("MovablePointDisplay", () => {
+  it("has a human-readable displayName", () => {
+    expect(MovablePointDisplay.displayName).toBe("MovablePointDisplay")
+  })
+})

--- a/src/display/MovablePointDisplay.tsx
+++ b/src/display/MovablePointDisplay.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import * as React from "react"
 import { vec } from "../vec"
 import { useTransformContext } from "../context/TransformContext"
 import { Theme } from "./Theme"

--- a/src/display/MovablePointDisplay.tsx
+++ b/src/display/MovablePointDisplay.tsx
@@ -1,0 +1,52 @@
+import React from "react"
+import { vec } from "../vec"
+import { useTransformContext } from "../context/TransformContext"
+import { Theme } from "./Theme"
+
+export interface MovablePointDisplayProps {
+  color?: string
+  ringRadiusPx?: number
+  dragging: boolean
+  point: vec.Vector2
+}
+
+export const MovablePointDisplay = React.forwardRef<SVGGElement, MovablePointDisplayProps>(
+  (props: MovablePointDisplayProps, ref) => {
+    const { color = Theme.pink, ringRadiusPx = 15, dragging, point } = props
+
+    const { viewTransform, userTransform } = useTransformContext()
+
+    const combinedTransform = React.useMemo(
+      () => vec.matrixMult(viewTransform, userTransform),
+      [viewTransform, userTransform],
+    )
+
+    const [xPx, yPx] = vec.transform(point, combinedTransform)
+
+    return (
+      <g
+        ref={ref}
+        style={
+          {
+            "--movable-point-color": color,
+            "--movable-point-ring-size": `${ringRadiusPx}px`,
+          } as React.CSSProperties
+        }
+        className={`mafs-movable-point ${dragging ? "mafs-movable-point-dragging" : ""}`}
+        tabIndex={0}
+      >
+        <circle className="mafs-movable-point-hitbox" r={30} cx={xPx} cy={yPx}></circle>
+        <circle
+          className="mafs-movable-point-focus"
+          r={ringRadiusPx + 1}
+          cx={xPx}
+          cy={yPx}
+        ></circle>
+        <circle className="mafs-movable-point-ring" r={ringRadiusPx} cx={xPx} cy={yPx}></circle>
+        <circle className="mafs-movable-point-point" r={6} cx={xPx} cy={yPx}></circle>
+      </g>
+    )
+  },
+)
+
+MovablePointDisplay.displayName = "MovablePointDisplay"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,8 +41,8 @@ export type { TextProps, CardinalDirection } from "./display/Text"
 export { Theme } from "./display/Theme"
 export type { Filled, Stroked } from "./display/Theme"
 
-export { MovablePoint } from "./interaction/MovablePoint"
-export type { MovablePointProps } from "./interaction/MovablePoint"
+export { MovablePoint, MovablePointSVG, useMovementInteraction } from "./interaction/MovablePoint"
+export type { MovablePointProps, MovablePointSVGProps } from "./interaction/MovablePoint"
 
 export { useMovablePoint } from "./interaction/useMovablePoint"
 export type {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,8 +41,17 @@ export type { TextProps, CardinalDirection } from "./display/Text"
 export { Theme } from "./display/Theme"
 export type { Filled, Stroked } from "./display/Theme"
 
-export { MovablePoint, MovablePointSVG, useMovementInteraction } from "./interaction/MovablePoint"
-export type { MovablePointProps, MovablePointSVGProps } from "./interaction/MovablePoint"
+export { MovablePoint } from "./interaction/MovablePoint"
+export type { MovablePointProps } from "./interaction/MovablePoint"
+
+export { MovablePointDisplay } from "./display/MovablePointDisplay"
+export type { MovablePointDisplayProps } from "./display/MovablePointDisplay"
+
+export { useMovementInteraction } from "./interaction/useMovementInteraction"
+export type {
+  UseMovementInteraction,
+  UseMovementInteractionArguments,
+} from "./interaction/useMovementInteraction"
 
 export { useMovablePoint } from "./interaction/useMovablePoint"
 export type {

--- a/src/interaction/MovablePoint.test.ts
+++ b/src/interaction/MovablePoint.test.ts
@@ -1,13 +1,7 @@
-import { MovablePoint, MovablePointSVG } from "./MovablePoint"
+import { MovablePoint } from "./MovablePoint"
 
 describe("MovablePoint", () => {
-    it("has a human-readable displayName", () => {
-        expect(MovablePoint.displayName).toBe("MovablePoint");
-    })
-})
-
-describe("MovablePointSVG", () => {
-    it("has a human-readable displayName", () => {
-        expect(MovablePointSVG.displayName).toBe("MovablePointSVG");
-    })
+  it("has a human-readable displayName", () => {
+    expect(MovablePoint.displayName).toBe("MovablePoint")
+  })
 })

--- a/src/interaction/MovablePoint.test.ts
+++ b/src/interaction/MovablePoint.test.ts
@@ -1,0 +1,13 @@
+import { MovablePoint, MovablePointSVG } from "./MovablePoint"
+
+describe("MovablePoint", () => {
+    it("has a human-readable displayName", () => {
+        expect(MovablePoint.displayName).toBe("MovablePoint");
+    })
+})
+
+describe("MovablePointSVG", () => {
+    it("has a human-readable displayName", () => {
+        expect(MovablePointSVG.displayName).toBe("MovablePointSVG");
+    })
+})

--- a/src/interaction/MovablePoint.tsx
+++ b/src/interaction/MovablePoint.tsx
@@ -31,14 +31,7 @@ export function MovablePoint({
 
   const { dragging } = useMovementInteraction({ gestureTarget: ref, onMove, point, constrain })
 
-  return (
-    <MovablePointDisplay
-      ref={ref}
-      point={point}
-      color={color}
-      dragging={dragging}
-    />
-  )
+  return <MovablePointDisplay ref={ref} point={point} color={color} dragging={dragging} />
 }
 
 MovablePoint.displayName = "MovablePoint"

--- a/src/interaction/MovablePoint.tsx
+++ b/src/interaction/MovablePoint.tsx
@@ -1,11 +1,8 @@
-import { useDrag } from "@use-gesture/react"
 import * as React from "react"
-import invariant from "tiny-invariant"
 import { Theme } from "../display/Theme"
-import { range } from "../math"
 import { vec } from "../vec"
-import { useTransformContext } from "../context/TransformContext"
-import { useSpanContext } from "../context/SpanContext"
+import { useMovementInteraction } from "./useMovementInteraction"
+import { MovablePointDisplay } from "../display/MovablePointDisplay"
 
 export type ConstraintFunction = (position: vec.Vector2) => vec.Vector2
 
@@ -24,128 +21,6 @@ export interface MovablePointProps {
   color?: string
 }
 
-export function useMovementInteraction({
-  target,
-  onMove,
-  point,
-  constrain,
-}: {
-  target: React.RefObject<Element>
-  onMove: (point: vec.Vector2) => unknown
-  point: vec.Vector2
-  constrain: (point: vec.Vector2) => vec.Vector2
-}): { dragging: boolean } {
-  const [dragging, setDragging] = React.useState(false)
-  const { xSpan, ySpan } = useSpanContext()
-  const { viewTransform, userTransform } = useTransformContext()
-
-  const inverseViewTransform = vec.matrixInvert(viewTransform)
-  invariant(inverseViewTransform, "The view transform must be invertible.")
-
-  const inverseTransform = React.useMemo(() => getInverseTransform(userTransform), [userTransform])
-
-  const pickup = React.useRef<vec.Vector2>([0, 0])
-
-  useDrag(
-    (state) => {
-      const { type, event } = state
-      event?.stopPropagation()
-
-      const isKeyboard = type.includes("key")
-      if (isKeyboard) {
-        event?.preventDefault()
-        const { direction: yDownDirection, altKey, metaKey, shiftKey } = state
-
-        const direction = [yDownDirection[0], -yDownDirection[1]] as vec.Vector2
-        const span = Math.abs(direction[0]) ? xSpan : ySpan
-
-        let divisions = 50
-        if (altKey || metaKey) divisions = 200
-        if (shiftKey) divisions = 10
-
-        const min = span / (divisions * 2)
-        const tests = range(span / divisions, span / 2, span / divisions)
-
-        for (const dx of tests) {
-          // Transform the test back into the point's coordinate system
-          const testMovement = vec.scale(direction, dx)
-          const testPoint = constrain(
-            vec.transform(
-              vec.add(vec.transform(point, userTransform), testMovement),
-              inverseTransform,
-            ),
-          )
-
-          if (vec.dist(testPoint, point) > min) {
-            onMove(testPoint)
-            break
-          }
-        }
-      } else {
-        const { last, movement: pixelMovement, first } = state
-
-        setDragging(!last)
-
-        if (first) pickup.current = vec.transform(point, userTransform)
-        if (vec.mag(pixelMovement) === 0) return
-
-        const movement = vec.transform(pixelMovement, inverseViewTransform)
-        onMove(constrain(vec.transform(vec.add(pickup.current, movement), inverseTransform)))
-      }
-    },
-    { target, eventOptions: { passive: false } },
-  )
-  return { dragging }
-}
-
-export interface MovablePointSVGProps {
-  color: string
-  ringRadiusPx: number
-  dragging: boolean
-  point: vec.Vector2
-}
-
-export const MovablePointSVG = React.forwardRef<SVGGElement, MovablePointSVGProps>(
-  (props: MovablePointSVGProps, ref) => {
-    const { color, ringRadiusPx, dragging, point } = props
-
-    const { viewTransform, userTransform } = useTransformContext()
-
-    const combinedTransform = React.useMemo(
-      () => vec.matrixMult(viewTransform, userTransform),
-      [viewTransform, userTransform],
-    )
-
-    const [xPx, yPx] = vec.transform(point, combinedTransform)
-
-    return (
-      <g
-        ref={ref}
-        style={
-          {
-            "--movable-point-color": color,
-            "--movable-point-ring-size": `${ringRadiusPx}px`,
-          } as React.CSSProperties
-        }
-        className={`mafs-movable-point ${dragging ? "mafs-movable-point-dragging" : ""}`}
-        tabIndex={0}
-      >
-        <circle className="mafs-movable-point-hitbox" r={30} cx={xPx} cy={yPx}></circle>
-        <circle
-          className="mafs-movable-point-focus"
-          r={ringRadiusPx + 1}
-          cx={xPx}
-          cy={yPx}
-        ></circle>
-        <circle className="mafs-movable-point-ring" r={ringRadiusPx} cx={xPx} cy={yPx}></circle>
-        <circle className="mafs-movable-point-point" r={6} cx={xPx} cy={yPx}></circle>
-      </g>
-    )
-  },
-)
-
-MovablePointSVG.displayName = "MovablePointSVG"
-
 export function MovablePoint({
   point,
   onMove,
@@ -154,20 +29,16 @@ export function MovablePoint({
 }: MovablePointProps) {
   const ref = React.useRef<SVGGElement>(null)
 
-  const { dragging } = useMovementInteraction({ target: ref, onMove, point, constrain })
+  const { dragging } = useMovementInteraction({ gestureTarget: ref, onMove, point, constrain })
 
   return (
-    <MovablePointSVG ref={ref} point={point} color={color} ringRadiusPx={15} dragging={dragging} />
+    <MovablePointDisplay
+      ref={ref}
+      point={point}
+      color={color}
+      dragging={dragging}
+    />
   )
 }
 
 MovablePoint.displayName = "MovablePoint"
-
-function getInverseTransform(transform: vec.Matrix) {
-  const invert = vec.matrixInvert(transform)
-  invariant(
-    invert !== null,
-    "Could not invert transform matrix. Your movable point's transformation matrix might be degenerative (mapping 2D space to a line).",
-  )
-  return invert
-}

--- a/src/interaction/useMovementInteraction.tsx
+++ b/src/interaction/useMovementInteraction.tsx
@@ -1,0 +1,94 @@
+import * as React from "react"
+import { useDrag } from "@use-gesture/react"
+import invariant from "tiny-invariant"
+import { vec } from "../vec"
+import { useSpanContext } from "../context/SpanContext"
+import { useTransformContext } from "../context/TransformContext"
+import { range } from "../math"
+
+export interface UseMovementInteractionArguments {
+  gestureTarget: React.RefObject<Element>
+  onMove: (point: vec.Vector2) => unknown
+  point: vec.Vector2
+  constrain: (point: vec.Vector2) => vec.Vector2
+}
+
+export interface UseMovementInteraction {
+  dragging: boolean
+}
+
+export function useMovementInteraction(
+  args: UseMovementInteractionArguments,
+): UseMovementInteraction {
+  const { gestureTarget: target, onMove, point, constrain } = args
+  const [dragging, setDragging] = React.useState(false)
+  const { xSpan, ySpan } = useSpanContext()
+  const { viewTransform, userTransform } = useTransformContext()
+
+  const inverseViewTransform = vec.matrixInvert(viewTransform)
+  invariant(inverseViewTransform, "The view transform must be invertible.")
+
+  const inverseTransform = React.useMemo(() => getInverseTransform(userTransform), [userTransform])
+
+  const pickup = React.useRef<vec.Vector2>([0, 0])
+
+  useDrag(
+    (state) => {
+      const { type, event } = state
+      event?.stopPropagation()
+
+      const isKeyboard = type.includes("key")
+      if (isKeyboard) {
+        event?.preventDefault()
+        const { direction: yDownDirection, altKey, metaKey, shiftKey } = state
+
+        const direction = [yDownDirection[0], -yDownDirection[1]] as vec.Vector2
+        const span = Math.abs(direction[0]) ? xSpan : ySpan
+
+        let divisions = 50
+        if (altKey || metaKey) divisions = 200
+        if (shiftKey) divisions = 10
+
+        const min = span / (divisions * 2)
+        const tests = range(span / divisions, span / 2, span / divisions)
+
+        for (const dx of tests) {
+          // Transform the test back into the point's coordinate system
+          const testMovement = vec.scale(direction, dx)
+          const testPoint = constrain(
+            vec.transform(
+              vec.add(vec.transform(point, userTransform), testMovement),
+              inverseTransform,
+            ),
+          )
+
+          if (vec.dist(testPoint, point) > min) {
+            onMove(testPoint)
+            break
+          }
+        }
+      } else {
+        const { last, movement: pixelMovement, first } = state
+
+        setDragging(!last)
+
+        if (first) pickup.current = vec.transform(point, userTransform)
+        if (vec.mag(pixelMovement) === 0) return
+
+        const movement = vec.transform(pixelMovement, inverseViewTransform)
+        onMove(constrain(vec.transform(vec.add(pickup.current, movement), inverseTransform)))
+      }
+    },
+    { target, eventOptions: { passive: false } },
+  )
+  return { dragging }
+}
+
+function getInverseTransform(transform: vec.Matrix) {
+  const invert = vec.matrixInvert(transform)
+  invariant(
+    invert !== null,
+    "Could not invert transform matrix. Your movable point's transformation matrix might be degenerative (mapping 2D space to a line).",
+  )
+  return invert
+}


### PR DESCRIPTION
## Summary:
Mafs comes with built-in support for movable points via the MovablePoint
component. These points can be dragged with the mouse or moved with the
arrow keys. However, we'd like to make other kinds of elements (line
segments, polygons) movable too, in a way that feels consistent with the
movement of points.

To achieve this consistency, we'd like to reuse the movement logic from
`MovablePoint`. To that end, we export a `useMovementInteraction` hook
from Mafs in this PR.

We also split out a presentational component that just renders the
MovablePoint SVG. We think we might want to create our own keyboard
movement logic in the future, with different meanings for the ctrl and
alt modifiers. Having a purely presentational component for movable
points will facilitate that.

Issue: https://khanacademy.atlassian.net/browse/LEMS-1672

Test plan:

```
yarn start
open http://localhost:3000
```

Navigate to the Movable Point page and play with the examples.

There are also Playwright e2e tests that cover MovablePoint.
To run them:

```bash
npx playwright install # one-time setup to globally install browsers
pnpm test
```